### PR TITLE
Make a fairy proof of concept.

### DIFF
--- a/slick/responses.lua
+++ b/slick/responses.lua
@@ -32,9 +32,10 @@ local function slide(world, query, response, x, y, goalX, goalY, filter)
 
     local newGoalX = _cachedSlideNewGoalPosition.x
     local newGoalY = _cachedSlideNewGoalPosition.y
+    local touchX, touchY = response.touch.x, response.touch.y
 
-    world:project(response.item, response.touch.x, response.touch.y, newGoalX, newGoalY, filter, query)
-    return response.touch.x, response.touch.y, newGoalX, newGoalY, "touch"
+    world:project(response.item, touchX, touchY, newGoalX, newGoalY, filter, query)
+    return touchX, touchY, newGoalX, newGoalY, "touch"
 end
 
 --- @param world slick.world

--- a/slick/world.lua
+++ b/slick/world.lua
@@ -459,7 +459,6 @@ function world:check(item, goalX, goalY, filter, query)
                 --- @diagnostic disable-next-line: cast-local-type
                 responseName = result.response
             end
-
         end
 
         --- @cast responseName string

--- a/slick/worldQuery.lua
+++ b/slick/worldQuery.lua
@@ -208,6 +208,10 @@ function worldQuery:performProjection(entity, x, y, goalX, goalY, filter)
     self:_endQuery()
 end
 
+function worldQuery:sort()
+    table.sort(self.results, worldQueryResponse.less)
+end
+
 function worldQuery:reset()
     slicktable.clear(self.results)
 end
@@ -239,7 +243,7 @@ end
 
 --- @private
 function worldQuery:_endQuery()
-    table.sort(self.results, worldQueryResponse.less)
+    self:sort()
 end
 
 --- @private


### PR DESCRIPTION
The fairy proof of concept is to see how to have an entity with "children" moving parts. Imagine, for example, a player character that can extend their hand like inspector gadget - you will want collision between the hand entity and player entity its attached to, without having to create and re-create the shapes of the primary player entity.

The `checkMany` function in `main.lua` is like `slick.world.check`, but it supports projecting and colliding multiple children entities relative to a parent entity.

See example here:

![fairy](https://github.com/user-attachments/assets/858fe446-127e-4f63-a061-96aa5e7a7171)