### PR TITLE
[#30] Fix potential memory leak.

### DIFF
--- a/slick/world.lua
+++ b/slick/world.lua
@@ -299,6 +299,8 @@ function world:remove(item)
 
     e:detach()
     table.insert(self.freeList, entityIndex)
+
+    self.itemToEntity[item] = nil
 end
 
 --- @param item any


### PR DESCRIPTION
Closes #30 

The `itemToEntity` field in `slick.world` (where the key is `item` and value is `index` into the `entities` array) was not cleared. This:

1. Meant the item (incorrectly) was returned by `slick.world.getItems`.
2. Also meant `item` would be (permanently) stored, causing a reference to stay around as long as the `slick.world` was around.