### PR TITLE
[#34] Simple triangulation & clipping API.

### DIFF
--- a/slick/geometry/init.lua
+++ b/slick/geometry/init.lua
@@ -7,6 +7,7 @@ local geometry = {
     ray = require("slick.geometry.ray"),
     rectangle = require("slick.geometry.rectangle"),
     segment = require("slick.geometry.segment"),
+    simple = require("slick.geometry.simple"),
     transform = require("slick.geometry.transform"),
 }
 

--- a/slick/geometry/rectangle.lua
+++ b/slick/geometry/rectangle.lua
@@ -92,9 +92,11 @@ function rectangle:overlaps(other)
 end
 
 --- @param p slick.geometry.point
+--- @param E number?
 --- @return boolean
-function rectangle:inside(p)
-    return p.x >= self:left() and p.x <= self:right() and p.y >= self:top() and p.y <= self:bottom()
+function rectangle:inside(p, E)
+    E = E or 0
+    return slickmath.withinRange(p.x, self:left(), self:right(), E) and slickmath.withinRange(p.y, self:top(), self:bottom(), E)
 end
 
 return rectangle

--- a/slick/geometry/simple.lua
+++ b/slick/geometry/simple.lua
@@ -1,0 +1,184 @@
+local clipper = require "slick.geometry.clipper"
+local delaunay = require "slick.geometry.triangulation.delaunay"
+local util = require "slick.util"
+local slickmath = require "slick.util.slickmath"
+
+local simple = {}
+
+--- @param contours number[][]
+--- @return number[], number[]
+local function _getPointEdges(contours)
+    local points = {}
+    local edges = {}
+
+    for _, contour in ipairs(contours) do
+        local numPoints = #points
+        for j = 1, #contour, 2 do
+            table.insert(points, contour[j])
+            table.insert(points, contour[j + 1])
+
+            table.insert(edges, (numPoints / 2) + (j + 1) / 2)
+            table.insert(edges, (numPoints / 2) + (slickmath.wrap(j, 2, #contour) + 1) / 2)
+        end
+    end
+
+    return points, edges
+end
+
+--- @param points number[]
+--- @param polygons number[][]?
+--- @return number[][]
+local function _getPolygons(points, polygons)
+    local result = {}
+
+    if not polygons then
+        return result
+    end
+
+    for _, polygon in ipairs(polygons) do
+        local resultPolygon = {}
+        for _, vertex in ipairs(polygon) do
+            local i = (vertex - 1) * 2 + 1
+
+            table.insert(resultPolygon, points[i])
+            table.insert(resultPolygon, points[i + 1])
+        end
+        table.insert(result, resultPolygon)
+    end
+
+    return result
+end
+
+local triangulateOptions = {
+    refine = true,
+    interior = true,
+    exterior = false,
+    polygonization = false
+}
+
+--- @param contours number[][]
+--- @return number[][]
+function simple.triangulate(contours)
+    local points, edges = _getPointEdges(contours)
+
+    local triangulator = delaunay.new()
+    local cleanPoints, cleanEdges = triangulator:clean(points, edges)
+    local triangles = triangulator:triangulate(cleanPoints, cleanEdges, triangulateOptions)
+
+    return _getPolygons(cleanPoints, triangles)
+end
+
+local polygonizeOptions = {
+    refine = true,
+    interior = true,
+    exterior = false,
+    polygonization = true,
+    maxPolygonVertexCount = math.huge
+}
+
+--- @overload fun(n: number, contours: number[][]): number[][]
+--- @overload fun(contours: number[][]): number[][]
+--- @return number[][]
+function simple.polygonize(n, b)
+    local points, edges
+    if type(n) == "number" then
+        polygonizeOptions.maxPolygonVertexCount = math.max(n, 3)
+        points, edges = _getPointEdges(b)
+    else
+        polygonizeOptions.maxPolygonVertexCount = math.huge
+        points, edges = _getPointEdges(n)
+    end
+
+    local triangulator = delaunay.new()
+    local cleanPoints, cleanEdges = triangulator:clean(points, edges)
+    local _, _, polygons = triangulator:triangulate(cleanPoints, cleanEdges, polygonizeOptions)
+
+    return _getPolygons(cleanPoints, polygons)
+end
+
+--- @class slick.simple.clipOperation
+--- @field operation slick.geometry.clipper.clipOperation
+--- @field subject number[][] | slick.simple.clipOperation
+--- @field other number[][] | slick.simple.clipOperation
+local clipOperation = {}
+local clipOperationMetatable = { __index = clipOperation }
+
+--- @package
+--- @param clipper slick.geometry.clipper
+function clipOperation:perform(clipper)
+    local subjectPoints, subjectEdges
+    if util.is(self.subject, clipOperation) then
+        subjectPoints, subjectEdges = self.subject:perform(clipper)
+    else
+        subjectPoints, subjectEdges = _getPointEdges(self.subject)
+    end
+
+    local otherPoints, otherEdges
+    if util.is(self.other, clipOperation) then
+        otherPoints, otherEdges = self.other:perform(clipper)
+    else
+        otherPoints, otherEdges = _getPointEdges(self.other)
+    end
+
+    return clipper:clip(self.operation, subjectPoints, subjectEdges, otherPoints, otherEdges)
+end
+
+--- @param subject number[][] | slick.simple.clipOperation
+--- @param other number[][] | slick.simple.clipOperation
+function simple.newUnionClipOperation(subject, other)
+    return setmetatable({
+        operation = clipper.union,
+        subject = subject,
+        other = other
+    }, clipOperationMetatable)
+end
+
+--- @param subject number[][] | slick.simple.clipOperation
+--- @param other number[][] | slick.simple.clipOperation
+function simple.newDifferenceClipOperation(subject, other)
+    return setmetatable({
+        operation = clipper.difference,
+        subject = subject,
+        other = other
+    }, clipOperationMetatable)
+end
+
+--- @param subject number[][] | slick.simple.clipOperation
+--- @param other number[][] | slick.simple.clipOperation
+function simple.newIntersectionClipOperation(subject, other)
+    return setmetatable({
+        operation = clipper.intersection,
+        subject = subject,
+        other = other
+    }, clipOperationMetatable)
+end
+
+
+--- @param operation slick.simple.clipOperation
+--- @param maxVertexCount number?
+--- @return number[][]
+function simple.clip(operation, maxVertexCount)
+    maxVertexCount = maxVertexCount or 3
+    assert(maxVertexCount >= 3, "max vertex count must be at least 3 (for triangles) or more (for polygons) and at most infinity (unlimited number of vertices per polygon)")
+
+    assert(util.is(operation, clipOperation))
+
+    local triangulator = delaunay.new()
+    local c = clipper.new(triangulator)
+
+    local clippedPoints, clippedEdges = operation:perform(c)
+
+    local result
+    if maxVertexCount == 3 then
+        local triangles = triangulator:triangulate(clippedPoints, clippedEdges, triangulateOptions)
+        result = triangles
+    else
+        polygonizeOptions.maxPolygonVertexCount = maxVertexCount
+        local _, _, polygons = triangulator:triangulate(clippedPoints, clippedEdges, polygonizeOptions)
+        result = polygons
+    end
+
+    return _getPolygons(clippedPoints, result)
+end
+
+return simple

--- a/slick/geometry/simple.lua
+++ b/slick/geometry/simple.lua
@@ -125,6 +125,7 @@ end
 
 --- @param subject number[][] | slick.simple.clipOperation
 --- @param other number[][] | slick.simple.clipOperation
+--- @return slick.simple.clipOperation
 function simple.newUnionClipOperation(subject, other)
     return setmetatable({
         operation = clipper.union,
@@ -135,6 +136,7 @@ end
 
 --- @param subject number[][] | slick.simple.clipOperation
 --- @param other number[][] | slick.simple.clipOperation
+--- @return slick.simple.clipOperation
 function simple.newDifferenceClipOperation(subject, other)
     return setmetatable({
         operation = clipper.difference,
@@ -145,6 +147,7 @@ end
 
 --- @param subject number[][] | slick.simple.clipOperation
 --- @param other number[][] | slick.simple.clipOperation
+--- @return slick.simple.clipOperation
 function simple.newIntersectionClipOperation(subject, other)
     return setmetatable({
         operation = clipper.intersection,
@@ -158,8 +161,7 @@ end
 --- @param maxVertexCount number?
 --- @return number[][]
 function simple.clip(operation, maxVertexCount)
-    maxVertexCount = maxVertexCount or 3
-    assert(maxVertexCount >= 3, "max vertex count must be at least 3 (for triangles) or more (for polygons) and at most infinity (unlimited number of vertices per polygon)")
+    maxVertexCount = math.max(maxVertexCount or 3, 3)
 
     assert(util.is(operation, clipOperation))
 

--- a/slick/init.lua
+++ b/slick/init.lua
@@ -118,5 +118,13 @@ return {
     newPolygonMeshShape = shape.newPolygonMesh,
     newShapeGroup = shape.newShapeGroup,
 
+    triangulate = geometry.simple.triangulate,
+    polygonize = geometry.simple.polygonize,
+    clip = geometry.simple.clip,
+
+    newUnionClipOperation = geometry.simple.newUnionClipOperation,
+    newIntersectionClipOperation = geometry.simple.newIntersectionClipOperation,
+    newDifferenceClipOperation = geometry.simple.newDifferenceClipOperation,
+
     drawWorld = draw
 }

--- a/slick/util/slickmath.lua
+++ b/slick/util/slickmath.lua
@@ -82,14 +82,14 @@ function slickmath.inside(a, b, c, d)
     return slickmath.sign(result)
 end
 
-local function _collinear(a, b, c, d)
+local function _collinear(a, b, c, d, E)
     local abl = math.min(a, b)
     local abh = math.max(a, b)
 
     local cdl = math.min(c, d)
     local cdh = math.max(c, d)
 
-    if cdh < abl or abh < cdl then
+    if cdh + E < abl or abh + E < cdl then
         return false
     end
 
@@ -110,7 +110,7 @@ function slickmath.collinear(a, b, c, d, E)
     local dabSign = slickmath.direction(d, a, b, E)
 
     if acdSign == 0 and bcdSign == 0 and cabSign == 0 and dabSign == 0 then
-        return _collinear(a.x, b.x, c.x, d.x) and _collinear(a.y, b.y, c.y, d.y)
+        return _collinear(a.x, b.x, c.x, d.x, E) and _collinear(a.y, b.y, c.y, d.y, E)
     end
 
     return false
@@ -138,7 +138,7 @@ function slickmath.intersection(a, b, c, d, E)
     end
 
     if acdSign == 0 and bcdSign == 0 and cabSign == 0 and dabSign == 0 then
-        return slickmath.collinear(a, b, c, d)
+        return slickmath.collinear(a, b, c, d, E)
     end
 
     local bax = b.x - a.x


### PR DESCRIPTION
* Fix precision issues with clipper.
* Fix incorrect logic when querying line segments in a quad tree.
* Add optional epsilon to line segment and point queries in a quad tree.
* Add simple triangulation and clipping API.

Closes #34 