### PR TITLE
[#40] Fix 'cross' response handler.

### DIFF
--- a/slick/responses.lua
+++ b/slick/responses.lua
@@ -15,27 +15,29 @@ local _cachedSlideDirection = point.new()
 --- @param goalX number
 --- @param goalY number
 --- @param filter slick.worldFilterQueryFunc
---- @return number, number, number, number, string?
-local function slide(world, query, response, x, y, goalX, goalY, filter)
+--- @param result slick.worldQuery
+--- @return number, number, number, number, string?, slick.worldQueryResponse?
+local function slide(world, query, response, x, y, goalX, goalY, filter, result)
     _cachedSlideCurrentPosition:init(x, y)
     _cachedSlideTouchPosition:init(response.touch.x, response.touch.y)
     _cachedSlideGoalPosition:init(goalX, goalY)
-
+    
     response.normal:left(_cachedSlideGoalDirection)
-
+    
     _cachedSlideCurrentPosition:direction(_cachedSlideGoalPosition, _cachedSlideNewGoalPosition)
     _cachedSlideNewGoalPosition:normalize(_cachedSlideDirection)
-
+    
     local goalDotDirection = _cachedSlideNewGoalPosition:dot(_cachedSlideGoalDirection)
     _cachedSlideGoalDirection:multiplyScalar(goalDotDirection, _cachedSlideGoalDirection)
     _cachedSlideTouchPosition:add(_cachedSlideGoalDirection, _cachedSlideNewGoalPosition)
-
+    
     local newGoalX = _cachedSlideNewGoalPosition.x
     local newGoalY = _cachedSlideNewGoalPosition.y
     local touchX, touchY = response.touch.x, response.touch.y
-
+    
+    result:push(response)
     world:project(response.item, touchX, touchY, newGoalX, newGoalY, filter, query)
-    return touchX, touchY, newGoalX, newGoalY, "touch"
+    return touchX, touchY, newGoalX, newGoalY, "touch", nil
 end
 
 --- @param world slick.world
@@ -46,12 +48,15 @@ end
 --- @param goalX number
 --- @param goalY number
 --- @param filter slick.worldFilterQueryFunc
---- @return number, number, number, number, string?
-local function touch(world, query, response, x, y, goalX, goalY, filter)
+--- @param result slick.worldQuery
+--- @return number, number, number, number, string?, slick.worldQueryResponse?
+local function touch(world, query, response, x, y, goalX, goalY, filter, result)
     local touchX, touchY = response.touch.x, response.touch.y
+    
+    result:push(response)
     world:project(response.item, x, y, response.touch.x, response.touch.y, filter, query)
-
-    return touchX, touchY, touchX, touchY, nil
+    
+    return touchX, touchY, touchX, touchY, nil, nil
 end
 
 --- @param world slick.world
@@ -62,10 +67,42 @@ end
 --- @param goalX number
 --- @param goalY number
 --- @param filter slick.worldFilterQueryFunc
---- @return number, number, number, number, string?
-local function cross(world, query, response, x, y, goalX, goalY, filter)
-    world:project(response.item, x, y, goalX, goalY, filter, query)
-    return goalX, goalY, goalX, goalY, nil
+--- @param result slick.worldQuery
+--- @return number, number, number, number, string?, slick.worldQueryResponse?
+local function cross(world, query, response, x, y, goalX, goalY, filter, result)
+    result:push(response)
+
+    local index = 1
+    local nextResponseName
+    for i = 2, #query.results do
+        local otherResponse = query.results[i]
+
+        if type(otherResponse.response) == "function" or type(otherResponse.response) == "table" then
+            nextResponseName = otherResponse.response(otherResponse.item, world, query, otherResponse, x, y, goalX, goalY)
+        elseif type(otherResponse.response) == "string" then
+            --- @diagnostic disable-next-line: cast-local-type
+            nextResponseName = otherResponse.response
+        else
+            nextResponseName = "slide"
+        end
+
+        otherResponse.response = nextResponseName
+
+        if nextResponseName == "cross" then
+            result:push(otherResponse)
+            index = i
+        else
+            break
+        end
+    end
+
+    if index == #query.results or #query.results == 0 then
+        world:project(response.item, x, y, goalX, goalY, filter, query)
+        return goalX, goalY, goalX, goalY, nil, nil
+    end
+
+    local nextResponse = query.results[index + 1]
+    return nextResponse.touch.x, nextResponse.touch.y, goalX, goalY, nil, nextResponse
 end
 
 return {

--- a/slick/util/common.lua
+++ b/slick/util/common.lua
@@ -1,0 +1,9 @@
+return {
+    is = function(obj, t)
+        return type(t) == "table" and type(obj) == "table" and getmetatable(obj) and getmetatable(obj).__index == t
+    end,
+
+    type = function(obj)
+        return type(obj) == "table" and getmetatable(obj) and getmetatable(obj).__index
+    end
+}

--- a/slick/util/init.lua
+++ b/slick/util/init.lua
@@ -1,9 +1,11 @@
+local common = require("slick.util.common")
+
 return {
     math = require("slick.util.slickmath"),
     pool = require("slick.util.pool"),
     search = require("slick.util.search"),
     table = require("slick.util.slicktable"),
-    is = function(obj, t)
-        return type(obj) == "table" and getmetatable(obj) and getmetatable(obj).__index == t
-    end
+
+    is = common.is,
+    type = common.type
 }


### PR DESCRIPTION
* Fix `cross` response handler.
* Fix bug where all responses were treated as `slide`.
* Changes to behavior of `slick.worldResponseFunc`
  * Add optional `slick.worldQueryRespone` return value. If a response handler returns a value other than nil, then `slick.world.check` will immediately attempt to handle the returned `slick.worldQueryResponse` without causing a bounce. See documentation updates.
* Formally documented `slick.worldResponseFunc`
* Improve documentation for `slick.worldQuery` and `slick.worldQueryResponse`
* Refactor to how pooled `slick.geometry.point` are handled in a `slick.worldQuery`. Now, the `slick.worldQuery` can automatically pool objects of a **slick** type (i.e., `slick.geometry.point` in this case) across **all** `slick.worldQueryResponse` children. Before, each `slick.worldQueryResponse` pooled its own `slick.geometry.point` specifically for contact points. Now these point instances are pooled across responses.
* Support moving an instance belonging to one `slick.util.pool` to another `slick.util.pool`. This is used by `slick.worldQuery` when `move`-ing a `slick.worldQueryResponse` from one query to another; any pooled `extra` fields will be transparently moved as well.

**Fixed behavior:** Objects of type `thing` were made to use the `cross` response handler.

![cross fix](https://github.com/user-attachments/assets/57a13fba-d824-40f3-b9db-17ebb3ebb3c1)

**Old behavior:** Objects of type `thing` behaved like `slide` when using `cross`.

![before cross fix](https://github.com/user-attachments/assets/817c6592-b866-4723-bb37-3eaadbf3bb3f)

Closes #40.