### PR TITLE
Minor bug fixes.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -227,7 +227,7 @@ local function makePlayer(world)
     }
 
     player.luigini = slick.newShapeGroup(
-        slick.newBoxShape(0, 0, player.w, player.h),
+        slick.newRectangleShape(0, 0, player.w, player.h),
         slick.newCircleShape(player.w / 2, 0, player.w / 2),
         slick.newCircleShape(player.w / 2, player.h, player.w / 2)
     )
@@ -415,18 +415,18 @@ local function makeLevel(world)
 
     world:add(level, slick.newTransform(), 
         slick.newShapeGroup(
-            slick.newBoxShape(0, 0, 8, h),
-            slick.newBoxShape(w - 8, 0, 8, h),
-            slick.newBoxShape(0, h - 8, w, 8),
-            slick.newBoxShape(0, -8, w, 8),
+            slick.newRectangleShape(0, 0, 8, h),
+            slick.newRectangleShape(w - 8, 0, 8, h),
+            slick.newRectangleShape(0, h - 8, w, 8),
+            slick.newRectangleShape(0, -8, w, 8),
             slick.newPolygonShape({ 8, h - h / 8, w / 4, h - 8, 8, h - 8 }),
             slick.newPolygonMeshShape({ w - w / 4, h, w - 8, h / 2, w - 8, h }, { w - w / 4, h, w - 8, h / 2, w - 8, h }),
-            slick.newBoxShape(w / 2 + w / 5, h - 150, w / 5, 60),
+            slick.newRectangleShape(w / 2 + w / 5, h - 150, w / 5, 60),
             slick.newPolygonMeshShape({ w / 2 + w / 4, h / 4, w / 2 + w / 4 + w / 8, h / 4 + h / 8, w / 2 + w / 4, h / 4 + h / 4, w / 2 + w / 4 + w / 16, h / 4 + h / 8 })
         )
     )
 
-    world:add({ type = "level" }, slick.newTransform(w / 3.25, h / 3.25, -math.pi / 4), slick.newBoxShape(-w / 8, -30, w / 4, 60))
+    world:add({ type = "level" }, slick.newTransform(w / 3.25, h / 3.25, -math.pi / 4), slick.newRectangleShape(-w / 8, -30, w / 4, 60))
 
     return level
 end

--- a/slick/collision/quadTreeNode.lua
+++ b/slick/collision/quadTreeNode.lua
@@ -207,7 +207,9 @@ function quadTreeNode:expand(bounds)
             for data in pairs(_cachedQuadTreeNodeData) do
                 --- @diagnostic disable-next-line: invisible
                 local r = self.tree.data[data]
-                child:insert(data, r)
+                if r:overlaps(child.bounds) then
+                    child:insert(data, r)
+                end
             end
         end
     end

--- a/slick/collision/shapeCollisionResolutionQuery.lua
+++ b/slick/collision/shapeCollisionResolutionQuery.lua
@@ -1001,6 +1001,11 @@ function shapeCollisionResolutionQuery:performProjection(selfShape, otherShape, 
         self:_performPolygonPolygonProjection(selfShape, otherShape, selfOffset, otherOffset, selfVelocity, otherVelocity)
     end
 
+    if self.collision then
+        self.normal:round(self.epsilon)
+        self.normal:normalize(self.normal)
+    end
+
     return self.collision
 end
 

--- a/slick/geometry/point.lua
+++ b/slick/geometry/point.lua
@@ -210,6 +210,12 @@ function point:normalize(result)
     end
 end
 
+--- @param E number
+function point:round(E)
+    self.x = math.floor(self.x / E) * E
+    self.y = math.floor(self.y / E) * E
+end
+
 --- @param result slick.geometry.point
 function point:negate(result)
     result.x = -self.x

--- a/slick/init.lua
+++ b/slick/init.lua
@@ -59,10 +59,10 @@ end
 do
     local basePath = PATH:gsub("%.", "/")
     if basePath == "" then
-        basePath = "."
+        basePath = "./"
     end
 
-    local pathPrefix = string.format("%s/?.lua;%s/?/init.lua", basePath, basePath)
+    local pathPrefix = string.format("%s?.lua;%s?/init.lua", basePath, basePath)
 
     local oldLuaPath = package.path
     local oldLovePath = love and love.filesystem and love.filesystem.getRequirePath()


### PR DESCRIPTION
* Make **slick** library paths look a little nicer in the traceback when **slick** is in a subdirectory.
* Fix greedy insert in quad tree node `expand` causing duplicate inserts and crashes.
* Clamp any component of a normal within epsilon of 0 when a collision is detected in `shapeCollisionResolutionQuery`
* Fix broken demo after breaking change. Whoops!