### PR TITLE
[#48] Add shape tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,27 +469,35 @@ There are methods to mutate the entity, but tread carefully:
 
 ### `slick.collision.shapelike` and shape definitions
 
-A `slick.collision.shapelike` can be a polygon, circle, box, or shape group. An entity can have multiple shapes via shape groups.
+A `slick.collision.shapelike` can be a polygon, circle, box, or shape group. An entity can have multiple shapes via shape groups. `slick.collision.shapelike` aren't instantiated directly; instead, you create a `slick.collision.shapeDefinition` constructor and pass in the physical properties of the shape. When adding a `slick.entity` to the world (or updating it), shape instances will be automatically constructed from the shape definitions.
 
-When adding or updating an `item` to the world, you can provide a `slick.collision.shapeDefinition`. The complete list of of shape definitions are:
+The only public field for a `slick.collision.shapelike` is a value called `tag`. This value is passed to a `slick.collision.shapeDefinition` constructor. `tag` can be any value. If not provided, `tag` will be `nil`.
 
-* `slick.newRectangleShape(x: number, y: number, w: number, h: number)`
+When adding or updating an `item` to the world, you can provide a `slick.collision.shapeDefinition`. The constructor for a `slick.collision.shapeDefinition` takes a list of properties that define the shape. All `slick.collision.shapeDefinition` constructors can take an optional `slick.tag` as the last value, which will be stored in the `tag` field of the `slick.collision.shapelike`. In order to to create a `slick.tag`, you can the `slick.newTag` constructor:
+
+* `slick.newTag(value: any): slick.tag`
+  
+  Instantiates an opaque `slick.tag` instance wrapping `value`. Keep in mind the `tag` field will be the `value` argument, **not** a `slick.tag` instance. All shape definition constructors optionally take a `slick.tag` as the last parameter.
+
+The complete list of of shape definitions are:
+
+* `slick.newRectangleShape(x: number, y: number, w: number, h: number, tag: slick.tag?)`
 
   A rectangle with its top-left corner relative to the entity at (`x`, `y`). The rectangle will have a width of `w` and a height of `h`.
 
   For example, if an entity is at `100, 150` and the box is created at `10, 10`, then the box will be at `110, 160` in the world.
 
-* `slick.newCircleShape(x: number, y: number, radius: number)`
+* `slick.newCircleShape(x: number, y: number, radius: number, tag: slick.tag?)`
 
   A rectangle with its center relative to the entity at (`x`, `y`). The rectangle will have a radius of `radius`.
 
-* `slick.newPolygonShape(vertices: number[])`
+* `slick.newPolygonShape(vertices: number[], tag: slick.tag?)`
 
   Creates a polygon from a list of vertices. The vertices are in the order `{ x1, y1, x2, y2, x3, y3, ..., xn, yn }`.
 
   The polygon **must** be a valid convex polygon. This means no self-intersections; all interior angles are less than 180 degrees; no holes; and no duplicate points. To create a polygon that might self-intersect, have holes, or be concave, use `slick.newPolygonMeshShape`.
 
-* `slick.newPolygonMeshShape(...contours: number[])`
+* `slick.newPolygonMeshShape(...contours: number[], tag: slick.tag?)`
 
   Creates a polygon mesh from a variable number of contours. The contours are in the form `{ x1, y1, x2, y2, x3, y3, ..., xn, yn }`.
   
@@ -497,9 +505,11 @@ When adding or updating an `item` to the world, you can provide a `slick.collisi
 
   Polygons can self-intersect; be concave; have holes; have duplicate points; have collinear edges; etc. However, the worse the quality of the input data, the longer the polygonization will take. Similarly, the more contours / points in the contour data, the longer the triangulation/polygonization will take.
 
-* `slick.newShapeGroup(...shapes: slick.collision.shapeDefinition)`
+* `slick.newShapeGroup(...shapes: slick.collision.shapeDefinition, tag: slick.tag?)`
   
   Create a group of shapes. Useful to put all level geometry in one entity, for example, or make a "capsule" shape for a player out of two circle and a box (or things of that nature).
+
+  The value stored in the `slick.tag` (if provided) will be inherited by all children shapes definition, unless the child shape definition has its own `slick.tag`.
 
 ### `slick.geometry.transform`
 

--- a/slick/collision/commonShape.lua
+++ b/slick/collision/commonShape.lua
@@ -5,6 +5,7 @@ local slickmath = require("slick.util.slickmath")
 local slicktable= require("slick.util.slicktable")
 
 --- @class slick.collision.commonShape
+--- @field tag any
 --- @field entity slick.entity?
 --- @field vertexCount number
 --- @field normalCount number

--- a/slick/collision/polygonMesh.lua
+++ b/slick/collision/polygonMesh.lua
@@ -1,6 +1,7 @@
 local polygon = require ("slick.collision.polygon")
 
 --- @class slick.collision.polygonMesh
+--- @field tag any
 --- @field entity slick.entity
 --- @field boundaries number[][]
 --- @field polygons slick.collision.polygon[]
@@ -66,7 +67,10 @@ function polygonMesh:build(triangulator)
             table.insert(outputVertices, y)
         end
 
-        table.insert(self.polygons, polygon.new(self.entity, unpack(outputVertices)))
+        local instantiatedPolygon = polygon.new(self.entity, unpack(outputVertices))
+        instantiatedPolygon.tag = self.tag
+
+        table.insert(self.polygons, instantiatedPolygon)
     end
 end
 

--- a/slick/collision/shapeGroup.lua
+++ b/slick/collision/shapeGroup.lua
@@ -2,37 +2,49 @@ local polygonMesh = require("slick.collision.polygonMesh")
 local util = require("slick.util")
 
 --- @class slick.collision.shapeGroup
+--- @field tag any
 --- @field entity slick.entity
 --- @field shapes slick.collision.shape[]
 local shapeGroup = {}
 local metatable = { __index = shapeGroup }
 
 --- @param entity slick.entity
+--- @param tag slick.tag?
 --- @param ... slick.collision.shapeDefinition
 --- @return slick.collision.shapeGroup
-function shapeGroup.new(entity, ...)
+function shapeGroup.new(entity, tag, ...)
     local result = setmetatable({
         entity = entity,
         shapes = {}
     }, metatable)
 
-    result:_addShapeDefinitions(...)
+    result:_addShapeDefinitions(tag, ...)
 
     return result
 end
 
 --- @private
+--- @param tag slick.tag?
 --- @param shapeDefinition slick.collision.shapeDefinition?
 --- @param ... slick.collision.shapeDefinition
-function shapeGroup:_addShapeDefinitions(shapeDefinition, ...)
+function shapeGroup:_addShapeDefinitions(tag, shapeDefinition, ...)
     if not shapeDefinition then
         return
     end
 
-    local shape = shapeDefinition.type.new(self.entity, unpack(shapeDefinition.arguments, 1, shapeDefinition.n))
-    self:_addShapes(shape)
+    local shape
+    if shapeDefinition.type == shapeGroup then
+        shape = shapeDefinition.type.new(self.entity, shapeDefinition.tag, unpack(shapeDefinition.arguments, 1, shapeDefinition.n))
+    else
+        shape = shapeDefinition.type.new(self.entity, unpack(shapeDefinition.arguments, 1, shapeDefinition.n))
+    end
 
-    self:_addShapeDefinitions(...)
+    local shapeTag = shapeDefinition.tag or tag
+    local tagValue = shapeTag and shapeTag.value
+    shape.tag = tagValue
+
+    self:_addShapes(shape)
+    self:_addShapeDefinitions(tag, ...)
 end
 
 --- @private

--- a/slick/entity.lua
+++ b/slick/entity.lua
@@ -70,7 +70,7 @@ function entity:setShapes(...)
         end
     end
 
-    self.shapes = shapeGroup.new(self, ...)
+    self.shapes = shapeGroup.new(self, nil, ...)
     if self.world then
         self.shapes:attach()
         self:_updateQuadTree()

--- a/slick/init.lua
+++ b/slick/init.lua
@@ -24,6 +24,9 @@ local responses
 --- @module "slick.shape"
 local shape
 
+--- @module "slick.tag"
+local tag
+
 --- @module "slick.util"
 local util
 
@@ -48,6 +51,7 @@ local function load()
     defaultOptions = require("slick.options")
     responses = require("slick.responses")
     shape = require("slick.shape")
+    tag = require("slick.tag")
     util = require("slick.util")
     world = require("slick.world")
     worldQuery = require("slick.worldQuery")
@@ -99,6 +103,7 @@ return {
     entity = entity,
     geometry = geometry,
     shape = shape,
+    tag = tag,
     util = util,
     world = world,
     worldQuery = worldQuery,
@@ -117,6 +122,7 @@ return {
     newPolylineShape = shape.newPolyline,
     newPolygonMeshShape = shape.newPolygonMesh,
     newShapeGroup = shape.newShapeGroup,
+    newTag = tag.new,
 
     triangulate = geometry.simple.triangulate,
     polygonize = geometry.simple.polygonize,

--- a/slick/shape.lua
+++ b/slick/shape.lua
@@ -4,16 +4,20 @@ local lineSegment = require("slick.collision.lineSegment")
 local polygon = require("slick.collision.polygon")
 local polygonMesh = require("slick.collision.polygonMesh")
 local shapeGroup = require("slick.collision.shapeGroup")
+local tag = require("slick.tag")
+local util = require("slick.util")
 
 --- @param x number
 --- @param y number
 --- @param w number
 --- @param h number
+--- @param tag slick.tag?
 --- @return slick.collision.shapeDefinition
-local function newRectangle(x, y, w, h)
+local function newRectangle(x, y, w, h, tag)
     return {
         type = box,
         n = 4,
+        tag = tag,
         arguments = { x, y, w, h }
     }
 end
@@ -21,11 +25,13 @@ end
 --- @param x number
 --- @param y number
 --- @param radius number
+--- @param tag slick.tag?
 --- @return slick.collision.shapeDefinition
-local function newCircle(x, y, radius)
+local function newCircle(x, y, radius, tag)
     return {
         type = circle,
         n = 3,
+        tag = tag,
         arguments = { x, y, radius }
     }
 end
@@ -34,21 +40,25 @@ end
 --- @param y1 number
 --- @param x2 number
 --- @param y2 number
+--- @param tag slick.tag
 --- @return slick.collision.shapeDefinition
-local function newLineSegment(x1, y1, x2, y2)
+local function newLineSegment(x1, y1, x2, y2, tag)
     return {
         type = lineSegment,
         n = 4,
+        tag = tag,
         arguments = { x1, y1, x2, y2 }
     }
 end
 
 --- @param vertices number[] a list of x, y coordinates in the form `{ x1, y1, x2, y2, ..., xn, yn }`
+--- @param tag slick.tag?
 --- @return slick.collision.shapeDefinition
-local function newPolygon(vertices)
+local function newPolygon(vertices, tag)
     return {
         type = polygon,
         n = #vertices,
+        tag = tag,
         arguments = { unpack(vertices) }
     }
 end
@@ -65,21 +75,40 @@ local function _newPolylineHelper(lines, i, j)
 end
 
 --- @param lines number[][] an array of segments in the form { { x1, y1, x2, y2 }, { x1, y1, x2, y2 }, ... }
+--- @param tag slick.tag?
 --- @return slick.collision.shapeDefinition
-local function newPolyline(lines)
+local function newPolyline(lines, tag)
     return {
         type = shapeGroup,
         n = #lines,
+        tag = tag,
         arguments = { _newPolylineHelper(lines) }
     }
+end
+
+--- @param ... any
+--- @return number, slick.tag?
+local function _getTagAndCount(...)
+    local n = select("#", ...)
+
+    local hasTag = false
+    local maybeTag = select(select("#", ...), ...)
+    if util.is(maybeTag, tag) then
+        return n - 1, maybeTag
+    end
+
+    return n, nil
 end
 
 --- @param ... number[] a list of x, y coordinates in the form `{ x1, y1, x2, y2, ..., xn, yn }`
 --- @return slick.collision.shapeDefinition
 local function newPolygonMesh(...)
+    local n, tag = _getTagAndCount(...)
+
     return {
         type = polygonMesh,
-        n = select("#", ...),
+        n = n,
+        tag = t,
         arguments = { ... }
     }
 end
@@ -87,15 +116,19 @@ end
 --- @alias slick.collision.shapeDefinition {
 ---     type: { new: fun(entity: slick.entity, ...: any): slick.collision.shapelike },
 ---     n: number,
+---     tag: slick.tag?,
 ---     arguments: table,
 --- }
 
---- @param ... slick.collision.shapeDefinition
+--- @param ... slick.collision.shapeDefinition | slick.tag
 --- @return slick.collision.shapeDefinition
 local function newShapeGroup(...)
+    local n, tag = _getTagAndCount(...)
+
     return {
         type = shapeGroup,
-        n = select("#", ...),
+        n = n,
+        tag = tag,
         arguments = { ... }
     }
 end


### PR DESCRIPTION
Add optional `tag` field to `slick.collision.shapelike` instances. This `tag` field can be populated by passing in a `slick.tag` (created by `slick.newTag`) to all `slick.collision.shapeDefinition` constructors. See `README.md` for more information.