### PR TITLE
Handle 'slide' response better when there's multiple collisions at the same time.

### DIFF
--- a/slick/worldQuery.lua
+++ b/slick/worldQuery.lua
@@ -304,4 +304,12 @@ function worldQuery:push(response, copy)
     table.insert(self.results, result)
 end
 
+--- @param other slick.worldQuery
+--- @param copy boolean?
+function worldQuery:move(other, copy)
+    for _, response in ipairs(self.results) do
+        other:push(response, copy)
+    end
+end
+
 return worldQuery


### PR DESCRIPTION
Before:

![before_slide](https://github.com/user-attachments/assets/c388951b-5024-410d-a843-1f6c34c6ff38)

(After trying to move up-right, the upper block had a normal of +Y which becomes -X after flip. The second collision in the response, which is the block that is aligned with the moving block, was never checked. It had a -X normal which became +Y, which when "slid", would allow movement.)

After:

![after_slide](https://github.com/user-attachments/assets/626f8e05-e6c3-4a0b-8583-f6f7e0f01eba)
