### PR TITLE
[#111] Fix origin (offset) and scale. Fix inverseTransformPoint.

### DIFF
--- a/slick/geometry/transform.lua
+++ b/slick/geometry/transform.lua
@@ -86,14 +86,14 @@ end
 --- @return number x
 --- @return number y
 function transform:transformPoint(x, y)
-    local ox = x + self.offsetX
-    local oy = y + self.offsetY
+    local ox = x - self.offsetX
+    local oy = y - self.offsetY
     local rx = ox * self.rotationCos - oy * self.rotationSin
     local ry = ox * self.rotationSin + oy * self.rotationCos
     local sx = rx * self.scaleX
     local sy = ry * self.scaleY
-    local resultX = sx + self.x - self.offsetX
-    local resultY = sy + self.y - self.offsetY
+    local resultX = sx + self.x
+    local resultY = sy + self.y
 
     return resultX, resultY
 end
@@ -119,14 +119,14 @@ end
 --- @return number x
 --- @return number y
 function transform:inverseTransformPoint(x, y)
-    local tx = x + self.offsetX - self.x
-    local ty = y + self.offsetY - self.y
+    local tx = x - self.x
+    local ty = y - self.y
     local sx = tx / self.scaleX
     local sy = ty / self.scaleY
-    local rx = sx * self.rotationCos - sy * self.rotationSin
-    local ry = -sx * -self.rotationSin + sy * self.rotationCos
-    local resultX = rx - self.offsetX
-    local resultY = ry - self.offsetY
+    local rx = sx * self.rotationCos + sy * self.rotationSin
+    local ry = sy * self.rotationCos - sx * self.rotationSin
+    local resultX = rx + self.offsetX
+    local resultY = ry + self.offsetY
 
     return resultX, resultY
 end


### PR DESCRIPTION
Closes #111.

Origin (offset) was being applied incorrectly. Similarly, the logic in `inverseTransformPoint` was wrong.

Now:

```lua
local t1 = slick.newTransform(200, 500, math.pi / 2, 2, 2, 8, 8)
local t2 = love.math.newTransform(200, 500, math.pi / 2, 2, 2, 8, 8)
print(t1:transformPoint(0, 0)) -- prints "216 484", incorrectly printed "176 508" in 4.0.5
print(t2:transformPoint(0, 0)) -- prints "216 484"
print(t1:inverseTransformPoint(200, 500)) -- prints "8 8", incorrectly printed "-12 -4" in 4.0.5
print(t2:inverseTransformPoint(200, 500)) -- prints "8 8"
```